### PR TITLE
add Ctrl-C handling on prompt

### DIFF
--- a/repl/prompt.go
+++ b/repl/prompt.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/c-bata/go-prompt"
 )
@@ -19,8 +20,11 @@ func runPrompt(executor func(string), completer func(prompt.Document) []prompt.S
 		prompt.OptionPrefixTextColor(prompt.LightGray),
 		prompt.OptionMaxSuggestion(length),
 		prompt.OptionShowCompletionAtStart(),
+		prompt.OptionAddKeyBind(
+			prompt.KeyBind{prompt.ControlC, func(*prompt.Buffer){
+				_ = syscall.Kill(syscall.Getpid(), syscall.SIGINT)
+			}}),
 	)
-
 	firstTime()
 	p.Run()
 }


### PR DESCRIPTION
Fixed:

_"Exit the CLI wallet with ctrl-c"_ Issue - https://github.com/spacemeshos/local-testnet/issues/3

Changes:

Added key binding to handle Ctlr-C on the raw terminal